### PR TITLE
Support for DNS SAN and revoking old certs

### DIFF
--- a/autole.sh
+++ b/autole.sh
@@ -115,5 +115,5 @@ done
 # Reload Apache only if necessary
 if [ "${APACHE_RELOAD}" = true ]; then
 	echo "Reloading Apache configuration"
-	apache2ctl -t && /etc/init.d/apache2 reload
+	apache2ctl -t && /etc/init.d/apache2 graceful
 fi

--- a/autole.sh
+++ b/autole.sh
@@ -57,13 +57,14 @@ function checkAndRenew() {
 		echo "test" > ${WEBROOT}/${ACMEPATH}/${TESTFILE}
 	
 		if curl --output /dev/null --silent --head --fail "${URL}"; then
+			OLDCERT=`readlink -f ${CERTFILE}`
 			COMMAND="${LEBIN} --renew-by-default -a webroot --webroot-path ${WEBROOT} --email ${LEEMAIL} --text --agree-tos"
 			DNS=`openssl x509 -noout -text -in ${CERTFILE} |grep DNS:|sed -e 's/ *DNS://g;s/,/ /g'`
 			for i in ${DNS}; do
 				COMMAND="${COMMAND} -d $i"
 			done
 			COMMAND="${COMMAND} auth"
-			${COMMAND}
+			${COMMAND} && ${LEBIN} revoke --cert-path ${OLDCERT}
 			APACHE_RELOAD=true
 		else
 			echo ""

--- a/autole.sh
+++ b/autole.sh
@@ -57,7 +57,13 @@ function checkAndRenew() {
 		echo "test" > ${WEBROOT}/${ACMEPATH}/${TESTFILE}
 	
 		if curl --output /dev/null --silent --head --fail "${URL}"; then
-			${LEBIN} --renew-by-default -a webroot --webroot-path ${WEBROOT} --email ${LEEMAIL} --text --agree-tos -d ${DOMAIN} auth
+			COMMAND="${LEBIN} --renew-by-default -a webroot --webroot-path ${WEBROOT} --email ${LEEMAIL} --text --agree-tos"
+			DNS=`openssl x509 -noout -text -in ${CERTFILE} |grep DNS:|sed -e 's/ *DNS://g;s/,/ /g'`
+			for i in ${DNS}; do
+				COMMAND="${COMMAND} -d $i"
+			done
+			COMMAND="${COMMAND} auth"
+			${COMMAND}
 			APACHE_RELOAD=true
 		else
 			echo ""


### PR DESCRIPTION
Thanks a lot for this great script! I've made some additions that you might like:
- Support for renewing certs with Subject Alternate Name DNS entries
- Revoking the old cert after the renew succeeds
- Restart Apache gracefully
